### PR TITLE
Fix filtering by clearing pagination pointers

### DIFF
--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -149,9 +149,13 @@ export function useProductSearch(
     if (minPrice) {
       parts.push(`variants.price:>="${minPrice}"`)
     }
+    setCursors({
+      before: null,
+      after: null,
+    })
     setQuery(parts.join(" "))
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters, allTags, allProductTypes, allVendors, maxPrice, minPrice)
+  }, [filters, allTags, allProductTypes, allVendors, maxPrice, minPrice, sortKey])
 
   useEffect(() => {
     const qs = queryString.stringify({


### PR DESCRIPTION
The pagination-pointer state `cursors` that is currently being set with `setCursors`, seems to be the culprit when it comes to how the filtering breaks sometimes. 

This can easily be tested by navigating back and forth on any product archive that has pagination available - followed by entering a search. A search, or a filtering of the products at this point, will return a data object with 0 products. Odd behaviour also occurs, if a filtering is attempted, while not on the first page.

By unsetting the navigation pointer state in this side-effect, and by adding the sortKey state to the dependency array, we can fully reset the search archive every time a filter is changed, or a new search is entered.